### PR TITLE
Issue #12 add filtering

### DIFF
--- a/controllers/table.controller.js
+++ b/controllers/table.controller.js
@@ -15,8 +15,14 @@ TableController = {
    */
   getDocumentsFromTable: (req, res) => {
     try {
+      // Get the filters if there are any.
+      filters = Object.keys(req.query).map((key) => ({
+        key,
+        value: req.query[key],
+      }));
+
       // Make the call to DynamoDB
-      DynamodbService.getDocumentsFromTable(req.params.tableName).then(
+      DynamodbService.getDocumentsFromTable(req.params.tableName, filters).then(
         (resp) => {
           // Success
           res.status(200).send(resp);

--- a/services/dynamodb.service.spec.js
+++ b/services/dynamodb.service.spec.js
@@ -9,6 +9,43 @@ const dynamoService = require('./dynamodb.service');
 chai.use(chaiHttp);
 chai.should();
 
+describe('getDynamodbFilters', () => {
+  it('should build the FilterExperession properly', async () => {
+    // Arrange
+    const filters = [
+      { key: 'mistborn', value: 'Vin' },
+      { key: 'elantris', value: '200' },
+    ];
+    const expected = 'mistborn=:mistborn AND elantris=:elantris';
+
+    // Act
+    actual = await dynamoService.getDynamodbFilters(filters);
+
+    // Assert
+    actual.filterExpression.should.equal(expected);
+  });
+
+  it('should build the ExpressionAttributeValues properly', async () => {
+    // Arrange
+    const filters = [
+      { key: 'mistborn', value: 'Vin' },
+      { key: 'elantris', value: '200' },
+    ];
+    const expected = { ':mistborn': 'Vin', ':elantris': 200 };
+
+    // Act
+    actual = await dynamoService.getDynamodbFilters(filters);
+
+    // Assert
+    actual.expressionAttributeValues[':mistborn'].should.equal(
+      expected[':mistborn']
+    );
+    actual.expressionAttributeValues[':elantris'].should.equal(
+      expected[':elantris']
+    );
+  });
+});
+
 describe('DynamodbService', () => {
   // The DynamoDB DocumentClient.
   let documentClient;
@@ -35,7 +72,7 @@ describe('DynamodbService', () => {
         });
 
         // Act
-        actual = await dynamoService.getDocumentsFromTable('documents');
+        actual = await dynamoService.getDocumentsFromTable('documents', []);
 
         // Assert
         actual.length.should.equal(expected.Items.length);
@@ -57,7 +94,7 @@ describe('DynamodbService', () => {
         });
 
         // Act
-        actual = await dynamoService.getDocumentsFromTable('documents');
+        actual = await dynamoService.getDocumentsFromTable('documents', []);
 
         // Assert
         chai.assert.fail('Failed to return the Dynamo ERROR');


### PR DESCRIPTION
closes #12 

Add filtering with query params.
Name the key and set the value. Multiple filters can be used.
If a value in a parameter can be a number it will be sent to DynamoDB as a number. This can cause a problem if a number in the DB is stored as a string but it is the only way to support number filters without some kind of templating.